### PR TITLE
Add map layer controls and plugins

### DIFF
--- a/scripts/visualization/generate_map.py
+++ b/scripts/visualization/generate_map.py
@@ -1,5 +1,6 @@
 import folium
 from folium.plugins import MarkerCluster
+from folium.plugins import HeatMap, Fullscreen, LocateControl
 import os
 from pathlib import Path
 import pandas as pd
@@ -190,7 +191,7 @@ def aggregate_filtered_class_data(
     return df_schools_to_display, count_filtered_classes, detailed_filtered_classes_info, school_summary_from_filtered
 
 def add_school_markers_to_map(
-    folium_map_object: folium.Map,
+    folium_map_object: folium.Map | folium.FeatureGroup,
     df_schools_to_display: pd.DataFrame,
     class_count_per_school: dict[str, int],
     filtered_class_details_per_school: dict[str, list[dict]],
@@ -289,6 +290,16 @@ def create_schools_map(
     """
     m = folium.Map(location=WARSAW_CENTER_COORDS, zoom_start=11)
 
+    # Base layers
+    folium.TileLayer('OpenStreetMap', name='Mapa standardowa').add_to(m)
+    folium.TileLayer('Stamen Terrain', name='Terenowa').add_to(m)
+    folium.TileLayer('Stamen Toner', name='Czarno-biała').add_to(m)
+    folium.TileLayer('cartodbpositron', name='Jasna').add_to(m)
+    folium.TileLayer('cartodbdark_matter', name='Ciemna').add_to(m)
+
+    Fullscreen().add_to(m)
+    LocateControl().add_to(m)
+
     if filters_info_html:
         legend_html = f'''
         <div style="position: fixed; top: 60px; left: 60px; width: 320px; z-index:9999; background-color: white; border:2px solid grey; border-radius:8px; padding: 10px; font-size: 14px; box-shadow: 2px 2px 8px #888;">
@@ -299,17 +310,27 @@ def create_schools_map(
         from folium import Element
         m.get_root().html.add_child(Element(legend_html))
 
+    markers_fg = folium.FeatureGroup(name="Szkoły (markery)")
+    heatmap_fg = folium.FeatureGroup(name="Heatmapa")
+
     if df_schools_to_display.empty:
         print("Brak szkół do wyświetlenia na mapie po zastosowaniu filtrów.")
-        # Save empty map anyway
     else:
-         add_school_markers_to_map(
-            m,
+        add_school_markers_to_map(
+            markers_fg,
             df_schools_to_display,
             class_count_per_school,
             filtered_class_details_per_school,
-            school_summary_from_filtered
+            school_summary_from_filtered,
         )
+
+        heat_data = df_schools_to_display[["SzkolaLat", "SzkolaLon"]].values.tolist()
+        if heat_data:
+            HeatMap(heat_data).add_to(heatmap_fg)
+
+    markers_fg.add_to(m)
+    heatmap_fg.add_to(m)
+    folium.LayerControl(collapsed=False).add_to(m)
     try:
         m.save(str(output_path))
         print(f"✔ Mapa zapisana jako: {output_path}")

--- a/scripts/visualization/streamlit_mapa_licea.py
+++ b/scripts/visualization/streamlit_mapa_licea.py
@@ -11,6 +11,7 @@ import sys
 from pathlib import Path
 import pandas as pd
 import folium
+from folium.plugins import HeatMap, Fullscreen, LocateControl
 from streamlit_folium import st_folium
 import numbers
 
@@ -38,17 +39,38 @@ def create_schools_map_streamlit(
     """
     m = folium.Map(location=WARSAW_CENTER_COORDS, zoom_start=11)
 
+    # Base layers
+    folium.TileLayer('OpenStreetMap', name='Mapa standardowa').add_to(m)
+    folium.TileLayer('Stamen Terrain', name='Terenowa').add_to(m)
+    folium.TileLayer('Stamen Toner', name='Czarno-biała').add_to(m)
+    folium.TileLayer('cartodbpositron', name='Jasna').add_to(m)
+    folium.TileLayer('cartodbdark_matter', name='Ciemna').add_to(m)
+
+    Fullscreen().add_to(m)
+    LocateControl().add_to(m)
+
+    markers_fg = folium.FeatureGroup(name="Szkoły (markery)")
+    heatmap_fg = folium.FeatureGroup(name="Heatmapa")
+
     if df_schools_to_display.empty:
         st.warning("Brak szkół do wyświetlenia na mapie po zastosowaniu filtrów.")
-        # Return empty map
     else:
         add_school_markers_to_map(
-            folium_map_object=m,
+            folium_map_object=markers_fg,
             df_schools_to_display=df_schools_to_display,
             class_count_per_school=class_count_per_school,
             filtered_class_details_per_school=filtered_class_details_per_school,
-            school_summary_from_filtered=school_summary_from_filtered
+            school_summary_from_filtered=school_summary_from_filtered,
         )
+
+        heat_data = df_schools_to_display[["SzkolaLat", "SzkolaLon"]].values.tolist()
+        if heat_data:
+            HeatMap(heat_data).add_to(heatmap_fg)
+
+    markers_fg.add_to(m)
+    heatmap_fg.add_to(m)
+    folium.LayerControl(collapsed=False).add_to(m)
+
     return m
 
 def main():


### PR DESCRIPTION
## Summary
- enhance Folium maps with layer control, heatmap overlay, geolocation and fullscreen plugins
- expose new layers in Streamlit map

## Testing
- `python -m py_compile scripts/visualization/generate_map.py scripts/visualization/streamlit_mapa_licea.py`
- `pytest -q` *(fails: `pytest` not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nowe funkcje**
  - Dodano możliwość wyboru różnych stylów mapy (OpenStreetMap, Stamen Terrain, Stamen Toner, CartoDB Positron, CartoDB Dark Matter).
  - Wprowadzono tryb pełnoekranowy oraz opcję lokalizacji użytkownika na mapie.
  - Dodano warstwę z markerami szkół oraz warstwę z heatmapą lokalizacji szkół, z możliwością przełączania widoczności tych warstw.

- **Ulepszenia**
  - Zwiększono interaktywność i czytelność mapy dzięki nowym warstwom i kontrolkom.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->