### PR TITLE
Add geolocation and fullscreen controls to map

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -116,6 +116,7 @@ Posty o procesie tworzenia
 *   **Generowanie wizualizacji:** Skrypt `scripts/visualization/generate_visuals.py` tworzy wykresy.
 *   **Generowanie interaktywnej mapy:** Skrypt `scripts/visualization/generate_map.py` tworzy mapę.
 *   **Grupowanie znaczników na mapie:** Dzięki `folium.plugins.MarkerCluster` ikony szkół łączą się w klastry, co zmniejsza bałagan wizualny i poprawia czytelność przy małym powiększeniu mapy.
+*   **Tryb pełnoekranowy i przycisk "Znajdź mnie":** Mapa wykorzystuje wtyczki `Fullscreen` oraz `LocateControl`, pozwalając na wygodne przełączanie na pełny ekran i szybkie odnalezienie bieżącej lokalizacji użytkownika.
 *   **Interaktywna aplikacja Streamlit:** Skrypt `scripts/visualization/streamlit_mapa_licea.py` uruchamia aplikację webową.
 
 ## Uwagi

--- a/scripts/visualization/generate_map.py
+++ b/scripts/visualization/generate_map.py
@@ -1,5 +1,5 @@
 import folium
-from folium.plugins import MarkerCluster
+from folium.plugins import MarkerCluster, Fullscreen, LocateControl
 import os
 from pathlib import Path
 import pandas as pd
@@ -288,6 +288,8 @@ def create_schools_map(
     wiele bliskich szkół nie nachodzi na siebie przy oddaleniu.
     """
     m = folium.Map(location=WARSAW_CENTER_COORDS, zoom_start=11)
+    Fullscreen().add_to(m)
+    LocateControl().add_to(m)
 
     if filters_info_html:
         legend_html = f'''

--- a/scripts/visualization/streamlit_mapa_licea.py
+++ b/scripts/visualization/streamlit_mapa_licea.py
@@ -11,6 +11,7 @@ import sys
 from pathlib import Path
 import pandas as pd
 import folium
+from folium.plugins import Fullscreen, LocateControl
 from streamlit_folium import st_folium
 import numbers
 
@@ -37,6 +38,8 @@ def create_schools_map_streamlit(
     Tworzy i zwraca mapę Folium z lokalizacjami szkół, korzystając z add_school_markers_to_map.
     """
     m = folium.Map(location=WARSAW_CENTER_COORDS, zoom_start=11)
+    Fullscreen().add_to(m)
+    LocateControl().add_to(m)
 
     if df_schools_to_display.empty:
         st.warning("Brak szkół do wyświetlenia na mapie po zastosowaniu filtrów.")


### PR DESCRIPTION
## Summary
- enhance map generation to include Fullscreen and LocateControl plugins
- expose the same controls in the Streamlit application
- document new map features in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
