### PR TITLE
Dodano link do Google Maps w adresie szkoły

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,7 @@ Zapytaj Devina o to repozytorium:
 *   **Grupowanie znaczników na mapie:** Dzięki `folium.plugins.MarkerCluster` ikony szkół łączą się w klastry, co zmniejsza bałagan wizualny i poprawia czytelność przy małym powiększeniu mapy.
 *   **Tryb pełnoekranowy i przycisk "Znajdź mnie":** Mapa wykorzystuje wtyczki `Fullscreen` oraz `LocateControl`, pozwalając na wygodne przełączanie na pełny ekran i szybkie odnalezienie bieżącej lokalizacji użytkownika.
 *   **Opcjonalna warstwa HeatMap:** Można włączyć podgląd gęstości szkół przyciskiem na mapie (w pliku HTML) lub checkboxem w aplikacji Streamlit.
+*   **Nawigacja do szkoły:** W okienku informacji adres szkoły jest klikalny i otwiera Google Maps z trasą do wybranej placówki.
 *   **Interaktywna aplikacja Streamlit:** Skrypt `scripts/visualization/streamlit_mapa_licea.py` uruchamia aplikację webową.
 
 ## Uwagi

--- a/scripts/visualization/generate_map.py
+++ b/scripts/visualization/generate_map.py
@@ -212,7 +212,13 @@ def add_school_markers_to_map(
         szk_id = row.get("SzkolaIdentyfikator")
 
         popup_html = f"<b>{row['NazwaSzkoly']}</b><br>"
-        popup_html += f"Adres: {row['AdresSzkoly']}<br>"
+        nav_url = (
+            "https://www.google.com/maps/dir/?api=1&destination="
+            f"{row['SzkolaLat']},{row['SzkolaLon']}"
+        )
+        popup_html += (
+            f"Adres: <a href='{nav_url}' target='_blank'>{row['AdresSzkoly']}</a><br>"
+        )
         popup_html += f"Dzielnica: {row['Dzielnica']}<br>"
 
         summary = school_summary_from_filtered.get(szk_id, {})


### PR DESCRIPTION
## Podsumowanie
- adres szkoły w okienku na mapie jest teraz klikalny i prowadzi do nawigacji w Google Maps
- zaktualizowana dokumentacja opisuje tę zmianę

## Testy
- `python scripts/tests/test_googlemaps_api.py` (oczekiwany błąd: ModuleNotFoundError: No module named 'googlemaps')