### PR TITLE
Uzupełnienie testów

### DIFF
--- a/tests/test_googlemaps_api_client.py
+++ b/tests/test_googlemaps_api_client.py
@@ -8,7 +8,23 @@ from scripts.api_clients.googlemaps_api import (
 )
 from unittest.mock import Mock
 import datetime
-from freezegun import freeze_time
+
+
+def _freeze_time(monkeypatch, ts: str) -> None:
+    dt = datetime.datetime.fromisoformat(ts)
+
+    class FrozenDate(datetime.date):
+        @classmethod
+        def today(cls):
+            return dt.date()
+
+    class FrozenDateTime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return dt if tz is None else dt.astimezone(tz)
+
+    monkeypatch.setattr(datetime, "date", FrozenDate)
+    monkeypatch.setattr(datetime, "datetime", FrozenDateTime)
 
 def test_get_travel_time(monkeypatch):
     # Przygotowanie mockowanego obiektu gmaps
@@ -273,8 +289,8 @@ def test_get_coordinates_for_addresses_batch_exception(monkeypatch):
     }
     assert coordinates == expected_coordinates
 
-@freeze_time("2025-05-17")  # Sobota
 def test_get_next_weekday_time_weekend(monkeypatch):
+    _freeze_time(monkeypatch, "2025-05-17")  # Sobota
     # Funkcja powinna zwrócić timestamp dla poniedziałku (19.05.2025) o 7:30
     expected_date = datetime.datetime(2025, 5, 19, 7, 30)
     expected_timestamp = int(expected_date.timestamp())
@@ -285,8 +301,8 @@ def test_get_next_weekday_time_weekend(monkeypatch):
     # Sprawdzenie wyników
     assert result_timestamp == expected_timestamp
 
-@freeze_time("2025-05-19 06:30:00")  # Poniedziałek, przed 7:30
 def test_get_next_weekday_time_weekday_before_hour(monkeypatch):
+    _freeze_time(monkeypatch, "2025-05-19 06:30:00")  # Poniedziałek, przed 7:30
     # Funkcja powinna zwrócić timestamp dla tego samego dnia (19.05.2025) o 7:30
     expected_date = datetime.datetime(2025, 5, 19, 7, 30)
     expected_timestamp = int(expected_date.timestamp())
@@ -297,8 +313,8 @@ def test_get_next_weekday_time_weekday_before_hour(monkeypatch):
     # Sprawdzenie wyników
     assert result_timestamp == expected_timestamp
 
-@freeze_time("2025-05-19 08:00:00")  # Poniedziałek, po 7:30
 def test_get_next_weekday_time_weekday_after_hour(monkeypatch):
+    _freeze_time(monkeypatch, "2025-05-19 08:00:00")  # Poniedziałek, po 7:30
     # Funkcja powinna zwrócić timestamp dla następnego dnia (20.05.2025) o 7:30
     expected_date = datetime.datetime(2025, 5, 20, 7, 30)
     expected_timestamp = int(expected_date.timestamp())
@@ -309,8 +325,8 @@ def test_get_next_weekday_time_weekday_after_hour(monkeypatch):
     # Sprawdzenie wyników
     assert result_timestamp == expected_timestamp
 
-@freeze_time("2025-05-23 08:00:00")  # Piątek, po 7:30
 def test_get_next_weekday_time_friday_after_hour(monkeypatch):
+    _freeze_time(monkeypatch, "2025-05-23 08:00:00")  # Piątek, po 7:30
     # Funkcja powinna zwrócić timestamp dla poniedziałku (26.05.2025) o 7:30
     expected_date = datetime.datetime(2025, 5, 26, 7, 30)
     expected_timestamp = int(expected_date.timestamp())

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -3,34 +3,92 @@ import pandas as pd
 import numpy as np
 from scripts.analysis.score import _compute_min_prog, add_metrics, compute_composite
 
-@pytest.mark.skip(reason="TODO: implement")
 def test__compute_min_prog_nan():
-    pass
+    df = pd.DataFrame({
+        "Prog_min_klasa": [np.nan, 150],
+        "Prog_min_szkola": [120, 130],
+    })
+    result = _compute_min_prog(df)
+    expected = pd.Series([120, 150], name="Prog_min_klasa")
+    pd.testing.assert_series_equal(result, expected, check_dtype=False)
 
-@pytest.mark.skip(reason="TODO: implement")
 def test__compute_min_prog_value():
-    pass
+    df = pd.DataFrame({
+        "Prog_min_klasa": [140],
+        "Prog_min_szkola": [120],
+    })
+    result = _compute_min_prog(df)
+    assert result.iloc[0] == 140
 
-@pytest.mark.skip(reason="TODO: implement")
 def test_add_metrics_columns():
-    pass
+    df = pd.DataFrame({
+        "RankingPoz": [1],
+        "CzasDojazdu": [20],
+        "Prog_min_klasa": [110],
+        "Prog_min_szkola": [100],
+        "PrzedmiotyRozszerzone": ["matematyka"],
+    })
+    out = add_metrics(df, P=130)
+    expected_cols = {
+        "Quality",
+        "AdmitProb",
+        "CommuteScore",
+        "ProfileMatch",
+        "MinProg",
+        "AdmitMargin",
+    }
+    assert expected_cols.issubset(out.columns)
 
-@pytest.mark.skip(reason="TODO: implement")
 def test_add_metrics_profile_match():
-    pass
+    df = pd.DataFrame({
+        "RankingPoz": [1, 2],
+        "CzasDojazdu": [10, 15],
+        "Prog_min_klasa": [100, 110],
+        "Prog_min_szkola": [90, 90],
+        "PrzedmiotyRozszerzone": ["matematyka", "historia"],
+    })
+    out = add_metrics(df, P=120, desired_subject="matematyka")
+    assert out["ProfileMatch"].tolist() == [1, 0]
 
-@pytest.mark.skip(reason="TODO: implement")
 def test_compute_composite_default_weights():
-    pass
+    df = pd.DataFrame({
+        "RankingPoz": [1, 2],
+        "CzasDojazdu": [10, 20],
+        "Prog_min_klasa": [100, 110],
+        "Prog_min_szkola": [90, 90],
+        "PrzedmiotyRozszerzone": ["mat", "his"],
+    })
+    out = add_metrics(df, P=130)
+    result = compute_composite(out)
+    assert "Composite" in result.columns
+    assert result.iloc[0]["Composite"] >= result.iloc[1]["Composite"]
 
-@pytest.mark.skip(reason="TODO: implement")
 def test_compute_composite_custom_weights():
-    pass
+    df = pd.DataFrame({
+        "RankingPoz": [1, 2],
+        "CzasDojazdu": [10, 20],
+        "Prog_min_klasa": [100, 110],
+        "Prog_min_szkola": [90, 90],
+        "PrzedmiotyRozszerzone": ["mat", "his"],
+    })
+    out = add_metrics(df, P=130, desired_subject="mat")
+    w = {"wQ": 0, "wA": 0, "wC": 0, "wP": 1}
+    result = compute_composite(out, w)
+    assert result.iloc[0]["ProfileMatch"] >= result.iloc[1]["ProfileMatch"]
 
-@pytest.mark.skip(reason="TODO: implement")
 def test_compute_composite_missing_columns():
-    pass
+    df = pd.DataFrame({"A": [1]})
+    with pytest.raises(ValueError):
+        compute_composite(df)
 
-@pytest.mark.skip(reason="TODO: implement")
 def test_compute_composite_sorting():
-    pass
+    df = pd.DataFrame({
+        "RankingPoz": [2, 1],
+        "CzasDojazdu": [20, 10],
+        "Prog_min_klasa": [110, 100],
+        "Prog_min_szkola": [100, 90],
+        "PrzedmiotyRozszerzone": ["his", "mat"],
+    })
+    out = add_metrics(df, P=130)
+    result = compute_composite(out)
+    assert list(result.index) == [1, 0]


### PR DESCRIPTION
## Podsumowanie
- zaimplementowano brakujące testy w `tests/test_score.py`
- usunięto zależność od biblioteki `freezegun` zastępując ją prostą funkcją `_freeze_time`
- zmodyfikowano testy korzystające z zamrażania czasu

## Testy
- `python -m pytest -q`