### PR TITLE
[deps] Ustalenie wersji Altair dla Streamlit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ aiohttp
 matplotlib
 seaborn
 folium
+altair<5
 streamlit
 streamlit-folium
 numpy


### PR DESCRIPTION
### Motivation
- W środowisku uruchomieniowym Streamlit próbował zaimportować `altair.vegalite.v4`, a zainstalowana wersja Altair była niekompatybilna (6.x), co powodowało błąd startu aplikacji; pinowanie wersji ma przywrócić kompatybilność.

### Description
- Dodano `altair<5` do `requirements.txt`, aby wymusić instalację wersji Altair zgodnej z importami używanymi przez projekt.

### Testing
- `black .` — uruchomiono i zakończono (brak zmian wymagających formatowania).
- `flake8 scripts tests` — nie przeszedł z powodu istniejących błędów stylu w repozytorium (niezwiązanych z tą zmianą).
- `mypy scripts` — nie przeszedł z powodu brakujących stubów i istniejących błędów typowania (niezwiązanych z tą zmianą).
- `pytest` — wszystkie testy jednostkowe przeszły (`63 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e6b27c46483308e435099a077f796)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Aktualizacje zależności**
  * Dodano ograniczenie wersji dla biblioteki Altair (altair<5) do konfiguracji wymagań Python, zapewniając kompatybilność i stabilność środowiska. Ta zmiana wpływa na proces instalacji zależności w projektach Python i pozwala na prawidłową rezolucję pakietów.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->