### PR TITLE
[streamlit] Wymuszenie nowszej wersji streamlit i przywrócenie placeholderow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,8 @@ aiohttp
 matplotlib
 seaborn
 folium
-streamlit
+altair>=5
+streamlit>=1.27
 streamlit-folium
 numpy
 pytest


### PR DESCRIPTION
### Motivation
- W srodowisku wdrozeniowym instalowala sie zbyt stara wersja `streamlit`, co powodowalo brak wsparcia dla argumentu `placeholder` w `st.multiselect` i niektore instancje aplikacji mogly sie nie uruchomic; zamiarem jest wymusic nowsza wersje zamiast usuwać UI.
- Dodatkowo wymagane jest dopasowanie wersji `altair` do nowego `streamlit` w celu zachowania zgodnosci zaleznosci.

### Description
- Zaktualizowano `requirements.txt`, ustawiajac `streamlit>=1.27` oraz `altair>=5` w celu wymuszenia nowszych wersji zaleznosci.
- Przywrocono argument `placeholder="Wybierz..."` we wszystkich wywolaniach `st.multiselect` w `scripts/visualization/streamlit_mapa_licea.py` (panel filtrowania).
- Zmiany obejmuja pliki `requirements.txt` oraz `scripts/visualization/streamlit_mapa_licea.py`.

### Testing
- `black .` — sukces.
- `flake8 scripts tests` — niepowodzenie z powodu istniejacych bledow stylu w repozytorium niezaleznych od tych zmian.
- `mypy scripts` — niepowodzenie z powodu brakujacych stubow i istniejacych problemow typowania w repozytorium.
- `pytest` — wszystkie testy jednostkowe przeszly (`63 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e6b27c46483308e435099a077f796)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Prace konserwacyjne**
  * Zaktualizowano zależności projektu w celu zapewnienia kompatybilności i stabilności aplikacji.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->